### PR TITLE
Add IT66122FN support

### DIFF
--- a/drivers/video/fl2000/fl2000_hdmi.c
+++ b/drivers/video/fl2000/fl2000_hdmi.c
@@ -978,7 +978,8 @@ fl2000_hdmi_find_chip(struct dev_ctx * dev_ctx)
                 const uint32_t deviceID = (data >> 16 & 0xFFF);
 
                 if (venderID == HDMI_ITE_VENDER_ID &&
-                    deviceID == HDMI_ITE_DEVICE_ID)
+			( deviceID == HDMI_ITE_DEVICE_ID ||
+		 	  deviceID == HDMI_ITE_DEVICE_ID_122 ))
                         found_hdmi = true;
         }
 

--- a/drivers/video/fl2000/fl2000_hdmi.h
+++ b/drivers/video/fl2000/fl2000_hdmi.h
@@ -16,6 +16,7 @@
 
 #define HDMI_ITE_VENDER_ID                      ( 0x4954 )
 #define HDMI_ITE_DEVICE_ID                      ( 0x612 )
+#define HDMI_ITE_DEVICE_ID_122                  ( 0x622 )
 
 #define HDMI_ITE_EACH_TIME_READ_EDID_MAX_SIZE   ( 0x20 )
 


### PR DESCRIPTION
IT66122FN is used for latest production of SE7 due to shortage of IT66121FN.

Please update support for it in fl2000 driver.
